### PR TITLE
Support linux as host for IntelliJ plugin

### DIFF
--- a/src/main/java/org/moe/common/exec/AbstractExec.java
+++ b/src/main/java/org/moe/common/exec/AbstractExec.java
@@ -123,7 +123,7 @@ public abstract class AbstractExec {
         if (exec == null) {
             throw new IOException("exec is null");
         }
-        if (OsUtils.isMac()) {
+        if (OsUtils.isMac() || OsUtils.isLinux()) {
             try {
                 File execFile = new File(exec);
                 if (execFile.exists() && !execFile.canExecute()) {

--- a/src/main/java/org/moe/common/exec/GradleExec.java
+++ b/src/main/java/org/moe/common/exec/GradleExec.java
@@ -35,7 +35,7 @@ public class GradleExec extends AbstractExec {
     static private String gradlew;
 
     static {
-        if (OsUtils.isMac()) {
+        if (OsUtils.isMac() || OsUtils.isLinux()) {
             gradlew = "gradlew";
         } else if (OsUtils.isWindows()) {
             gradlew = "gradlew.bat";

--- a/src/main/java/org/moe/common/exec/SimpleExec.java
+++ b/src/main/java/org/moe/common/exec/SimpleExec.java
@@ -30,7 +30,7 @@ public class SimpleExec extends AbstractExec {
     static private String lookupCommand;
 
     static {
-        if (OsUtils.isMac()) {
+        if (OsUtils.isMac() || OsUtils.isLinux()) {
             lookupCommand = "which";
         } else if (OsUtils.isWindows()) {
             lookupCommand = "where";

--- a/src/main/java/org/moe/common/utils/NativeUtil.java
+++ b/src/main/java/org/moe/common/utils/NativeUtil.java
@@ -45,6 +45,11 @@ public class NativeUtil {
      * Constant for Mac OS X.
      */
     public static final String OS_NAME_WINDOWS = "Windows";
+
+    /**
+     * Constant for Linux.
+     */
+    public static final String OS_NAME_LINUX = "Linux";
     /**
      * Constant for x86_64 arch.
      */

--- a/src/main/java/org/moe/common/utils/OsUtils.java
+++ b/src/main/java/org/moe/common/utils/OsUtils.java
@@ -51,6 +51,15 @@ public class OsUtils {
     }
 
     /**
+     * Tells whether or not the host is Linux or not.
+     *
+     * @return True if the host is Linux
+     */
+    public static boolean isLinux() {
+        return getOsName().startsWith("Linux");
+    }
+
+    /**
      * Returns the name and version of the host OS.
      *
      * @return name and version of the host OS


### PR DESCRIPTION
This is just a simple change to enable the IntelliJ plugin to handle linux as host, e.g. through executing gradle tasks.

Other pr's will follow regarding the gradle plugin and libimobildedevice, but this should be also safe to merge seperate.