### PR TITLE
JarFile needs to be closed too

### DIFF
--- a/src/main/kotlin/org/moe/common/utils/FileUtils.kt
+++ b/src/main/kotlin/org/moe/common/utils/FileUtils.kt
@@ -30,14 +30,14 @@ fun File.classpathIterator(consumer: (path: String, inputStream: InputStream) ->
                 consumer(relPath.path, it) }
         }
     } else if (this.name.endsWith(".jar")) {
-        val file = JarFile(this)
+        JarFile(this).use { file ->
+            file.stream().forEach jar@{ entry ->
+                if (entry.isDirectory || !filter(entry.name)) {
+                    return@jar
+                }
 
-        file.stream().forEach jar@{ entry ->
-            if (entry.isDirectory || !filter(entry.name)) {
-                return@jar
+                file.getInputStream(entry).use { consumer(entry.name, it) }
             }
-
-            file.getInputStream(entry).use { consumer(entry.name, it) }
         }
     }
 }


### PR DESCRIPTION
This fixes a issue that I encontered on windows with the r8 branch, however I think this is a general fix for windows as host maschine.
The issue that I encountered was the "File is used by another process" exception.